### PR TITLE
test: add initial auth and character smoke tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
         
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 

--- a/src/test/java/com/p3212/Configurations/AuthControllerTest.java
+++ b/src/test/java/com/p3212/Configurations/AuthControllerTest.java
@@ -1,0 +1,100 @@
+package com.p3212.Configurations;
+
+import com.p3212.Services.CharacterService;
+import com.p3212.Services.StatsService;
+import com.p3212.Services.UserService;
+import com.p3212.Repositories.RoleRepository;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Minimal smoke tests for {@link AuthController} to lock in
+ * current behaviour of /checkCookies.
+ *
+ * These are deliberately narrow and will be replaced or
+ * extended during the modernization work.
+ */
+public class AuthControllerTest {
+
+    private AuthController controller;
+
+    @Before
+    public void setUp() {
+        controller = new AuthController();
+        // For the methods we test here, autowired collaborators are not used,
+        // so we only need to ensure the controller instance can be created.
+        // (Mockito mocks are created to make future extensions easier.)
+        UserService userService = mock(UserService.class);
+        RoleRepository roleRepository = mock(RoleRepository.class);
+        CharacterService characterService = mock(CharacterService.class);
+        StatsService statsService = mock(StatsService.class);
+        WebSocketsController wsController = mock(WebSocketsController.class);
+        AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+
+        // Use reflection to inject mocks without changing production code.
+        // This keeps the test simple and non-invasive.
+        TestReflection.setField(controller, "userService", userService);
+        TestReflection.setField(controller, "roleRepository", roleRepository);
+        TestReflection.setField(controller, "charServ", characterService);
+        TestReflection.setField(controller, "statsService", statsService);
+        TestReflection.setField(controller, "wsController", wsController);
+        TestReflection.setField(controller, "notifServ", wsController);
+        TestReflection.setField(controller, "authManager", authenticationManager);
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void checkCookiesReturnsAuthorizedTrueWhenUserAuthenticated() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "testUser",
+                "password",
+                Collections.singletonList(new SimpleGrantedAuthority("USER"))
+        );
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        ResponseEntity response = controller.checkCookies();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(String.valueOf(response.getBody()).contains("\"authorized\": true"));
+        assertTrue(String.valueOf(response.getBody()).contains("\"login\":\"testUser\""));
+    }
+
+    @Test
+    public void checkCookiesReturnsUnauthorizedWhenAnonymous() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "anonymoususer",
+                "N/A",
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+        );
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        ResponseEntity response = controller.checkCookies();
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertTrue(String.valueOf(response.getBody()).contains("\"authorized\": false"));
+    }
+}
+

--- a/src/test/java/com/p3212/Configurations/TestReflection.java
+++ b/src/test/java/com/p3212/Configurations/TestReflection.java
@@ -1,0 +1,34 @@
+package com.p3212.Configurations;
+
+import java.lang.reflect.Field;
+
+/**
+ * Small helper for tests to inject dependencies into classes
+ * that are normally wired by Spring.
+ *
+ * This is intentionally minimal and kept in test scope only.
+ */
+public final class TestReflection {
+
+    private TestReflection() {
+        // utility
+    }
+
+    public static void setField(Object target, String fieldName, Object value) {
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to set field '" + fieldName + "'", e);
+            }
+        }
+        throw new IllegalArgumentException("Field '" + fieldName + "' not found on " + target.getClass());
+    }
+}
+

--- a/src/test/java/com/p3212/EntityClasses/CharacterChangeXPTest.java
+++ b/src/test/java/com/p3212/EntityClasses/CharacterChangeXPTest.java
@@ -1,0 +1,47 @@
+package com.p3212.EntityClasses;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Smoke tests for {@link Character#changeXP(int)} to ensure that
+ * level and upgrade points are derived from experience as expected.
+ */
+public class CharacterChangeXPTest {
+
+    @Test
+    public void changeXpAwardsLevelsAndUpgradePointsPerThousandXp() {
+        Stats stats = new Stats(50, 0, 0, 0, 0, 900, 1, 0);
+        User user = new User();
+        user.setStats(stats);
+
+        Character character = new Character(0.1f, 100, 10, 30);
+        character.setUser(user);
+
+        character.changeXP(300);
+
+        // 900 + 300 = 1200 XP => +1 level, +3 upgrade points
+        assertEquals(1200, user.getStats().getExperience());
+        assertEquals(2, user.getStats().getLevel());
+        assertEquals(3, user.getStats().getUpgradePoints());
+    }
+
+    @Test
+    public void changeXpCanAwardMultipleLevelsAtOnce() {
+        Stats stats = new Stats(50, 0, 0, 0, 0, 100, 1, 0);
+        User user = new User();
+        user.setStats(stats);
+
+        Character character = new Character(0.1f, 100, 10, 30);
+        character.setUser(user);
+
+        character.changeXP(2100);
+
+        // 100 + 2100 = 2200 XP => +2 levels, +6 upgrade points
+        assertEquals(2200, user.getStats().getExperience());
+        assertEquals(3, user.getStats().getLevel());
+        assertEquals(6, user.getStats().getUpgradePoints());
+    }
+}
+


### PR DESCRIPTION
This PR adds a minimal test stack via spring-boot-starter-test plus two small smoke test classes:\n\n- AuthControllerTest: verifies the current behaviour of /checkCookies for authenticated vs anonymous sessions via SecurityContextHolder.\n- CharacterChangeXPTest: verifies Character.changeXP(int) updates experience, level, and upgrade points according to the existing XP-to-level rules.\n\nThese are deliberately narrow and will be extended in later tasks to cover registration flows and fight mechanics more deeply.

Made with [Cursor](https://cursor.com)