### PR TITLE
[Backend] Upgrade to Spring Boot 4.0.3, Spring Framework 7, Spring Security 7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
   java
-  id("org.springframework.boot") version "3.5.11"
+  id("org.springframework.boot") version "4.0.3"
 }
 
 group = "com.anf"
@@ -20,28 +20,18 @@ repositories {
 }
 
 dependencies {
-  // Import the Spring Boot BOM for managed dependency versions
-  implementation(platform("org.springframework.boot:spring-boot-dependencies:3.5.11"))
+  implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.3"))
 
-  // Spring Boot starters
+  // Spring Boot starters (Boot 4 renames)
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-  implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-webmvc")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-validation")
-
-  // Spring WebSocket / Messaging
-  implementation("org.springframework:spring-websocket")
-  implementation("org.springframework:spring-messaging")
-
-  // Spring Security OAuth2 client (used for Google OAuth in auth-google-only PR)
-  implementation("org.springframework.security:spring-security-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-websocket")
+  implementation("org.springframework.boot:spring-boot-starter-security-oauth2-client")
 
   // Database
   implementation("org.postgresql:postgresql")
-
-  // Jackson (versions managed by Boot BOM)
-  implementation("com.fasterxml.jackson.core:jackson-core")
-  implementation("com.fasterxml.jackson.core:jackson-databind")
 
   // Lombok
   compileOnly("org.projectlombok:lombok:1.18.42")

--- a/src/main/java/com/anf/Application.java
+++ b/src/main/java/com/anf/Application.java
@@ -2,7 +2,7 @@ package com.anf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication

--- a/src/main/java/com/anf/config/SecurityConfiguration.java
+++ b/src/main/java/com/anf/config/SecurityConfiguration.java
@@ -1,80 +1,85 @@
 package com.anf.config;
 
-import com.anf.service.AuthService;
+import java.util.List;
 import javax.sql.DataSource;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
-
-/** Security configuration – username/password auth only for now. Google OAuth2 login will be
- * added in the auth-google-only refactoring step. */
+/**
+ * Security configuration – username/password auth only for now. Google OAuth2 login will be added
+ * in the auth-google-only refactoring step.
+ */
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class SecurityConfiguration {
 
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final DataSource dataSource;
   private final AuthenticationSuccessHandler successHandler;
   private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
-  private final AuthService authService;
 
-  private final SimpleUrlAuthenticationFailureHandler failureHandler =
+  private static final SimpleUrlAuthenticationFailureHandler FAILURE_HANDLER =
       new SimpleUrlAuthenticationFailureHandler();
 
   @Bean
-  public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-    return http.getSharedObject(AuthenticationManagerBuilder.class)
-        .jdbcAuthentication()
-        .usersByUsernameQuery("select login, password, true from users where login=?")
-        .authoritiesByUsernameQuery("select login, role from user_role where login=?")
-        .dataSource(dataSource)
-        .passwordEncoder(bCryptPasswordEncoder)
-        .and()
-        .build();
+  public UserDetailsService userDetailsService() {
+    var manager = new JdbcUserDetailsManager(dataSource);
+    manager.setUsersByUsernameQuery("select login, password, true from users where login=?");
+    manager.setAuthoritiesByUsernameQuery("select login, role from user_role where login=?");
+    return manager;
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(UserDetailsService userDetailsService) {
+    var provider = new DaoAuthenticationProvider(userDetailsService);
+    provider.setPasswordEncoder(bCryptPasswordEncoder);
+    return new ProviderManager(provider);
   }
 
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
-    CorsConfiguration config = new CorsConfiguration();
+    var config = new CorsConfiguration();
     config.setAllowedOriginPatterns(List.of("*"));
     config.setAllowedMethods(List.of("POST", "GET", "DELETE"));
     config.setAllowCredentials(true);
     config.setAllowedHeaders(List.of("*"));
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    var source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config);
     return source;
   }
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
-        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .csrf(csrf -> csrf.disable())
         .exceptionHandling(ex -> ex.authenticationEntryPoint(restAuthenticationEntryPoint))
-        .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/checkCookies", "/registration", "/confirm").permitAll()
-            .requestMatchers("/admin/**").hasRole("ADMIN")
-            .requestMatchers("/").permitAll()
-            .anyRequest().authenticated())
-        .formLogin(form -> form
-            .successHandler(successHandler)
-            .failureHandler(failureHandler))
-        .logout(logout -> logout
-            .deleteCookies("JSESSIONID")
-            .logoutSuccessUrl("/logout-success"));
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/checkCookies", "/registration", "/confirm")
+                    .permitAll()
+                    .requestMatchers("/admin/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .formLogin(form -> form.successHandler(successHandler).failureHandler(FAILURE_HANDLER))
+        .logout(logout -> logout.deleteCookies("JSESSIONID").logoutSuccessUrl("/logout-success"));
 
     return http.build();
   }

--- a/src/main/java/com/anf/model/Boss.java
+++ b/src/main/java/com/anf/model/Boss.java
@@ -1,7 +1,7 @@
 package com.anf.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -107,7 +107,7 @@ public class Boss extends Creature implements Serializable {
   public String toString() {
     try {
       return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
   }

--- a/src/main/java/com/anf/model/GameCharacter.java
+++ b/src/main/java/com/anf/model/GameCharacter.java
@@ -1,8 +1,8 @@
 package com.anf.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -239,7 +239,7 @@ public class GameCharacter extends Creature implements Serializable {
   public String toString() {
     try {
       return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
     //        return "Character{" +

--- a/src/main/java/com/anf/model/NinjaAnimal.java
+++ b/src/main/java/com/anf/model/NinjaAnimal.java
@@ -1,7 +1,7 @@
 package com.anf.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -101,7 +101,7 @@ public class NinjaAnimal extends Creature implements Serializable {
   public String toString() {
     try {
       return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
   }

--- a/src/main/java/com/anf/model/PrivateMessage.java
+++ b/src/main/java/com/anf/model/PrivateMessage.java
@@ -1,7 +1,7 @@
 package com.anf.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.util.Date;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -115,7 +115,7 @@ public class PrivateMessage {
   public String toString() {
     try {
       return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
     //        return "{" +

--- a/src/main/java/com/anf/model/Stats.java
+++ b/src/main/java/com/anf/model/Stats.java
@@ -1,8 +1,8 @@
 package com.anf.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -180,7 +180,7 @@ public class Stats {
     ObjectMapper mapper = new ObjectMapper();
     try {
       return mapper.writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return "{}";
     }
     //        return "\"{ username\": \"" + user.getLogin() +

--- a/src/main/java/com/anf/model/User.java
+++ b/src/main/java/com/anf/model/User.java
@@ -3,8 +3,8 @@ package com.anf.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
@@ -202,7 +202,7 @@ public class User implements Serializable {
   public String toString() {
     try {
       return new ObjectMapper().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       System.out.println(e.getMessage());
       return "{}";
     }


### PR DESCRIPTION
## Summary

- Upgrades from **Spring Boot 3.5.11 → 4.0.3** (Spring Framework 7, Spring Security 7, Spring Data 2025.1, Hibernate 7, Jackson 3)
- Migrates all Jackson 2 → Jackson 3 imports across 6 model classes
- Rewrites `SecurityConfiguration` for Spring Security 7 (removed APIs)

### build.gradle.kts
- Plugin and BOM bumped to `4.0.3`
- Starter renames per Boot 4 migration guide: `spring-boot-starter-web` → `spring-boot-starter-webmvc`, `spring-security-oauth2-client` → `spring-boot-starter-security-oauth2-client`
- Added `spring-boot-starter-websocket` (proper starter, replaces manual `spring-websocket` / `spring-messaging` deps)
- Removed explicit Jackson dependencies — they're now pulled transitively by starters

### Jackson 2 → 3
- `com.fasterxml.jackson.core.*` → `tools.jackson.core.*` and `com.fasterxml.jackson.databind.*` → `tools.jackson.databind.*`
- `JsonProcessingException` (removed in Jackson 3) → `JacksonException`
- `com.fasterxml.jackson.annotation.*` imports **stay unchanged** — the annotation module kept its original package per Jackson 3 design

### Spring Security 7
- `AuthenticationManagerBuilder` was removed — replaced with a `JdbcUserDetailsManager` bean + `DaoAuthenticationProvider` (its no-arg constructor was also removed; it now requires `UserDetailsService`)
- Removed unused `AuthService` from SecurityConfiguration

### Spring Data 2025.1
- `@EntityScan` import moved to `org.springframework.boot.persistence.autoconfigure.EntityScan`

## Build verification

```
./gradlew build   # 35/35 tests pass
```

## Test plan

- [ ] Run `./gradlew build` — 35 tests pass, `build/libs/ANF-4.3.jar` produced
- [ ] Confirm no `com.fasterxml.jackson.core` or `com.fasterxml.jackson.databind` imports remain in source (`com.fasterxml.jackson.annotation` is expected)
- [ ] Confirm no `AuthenticationManagerBuilder` usage remains


Made with [Cursor](https://cursor.com)